### PR TITLE
[NDGL-18] 로그인 및 유저 생성 API 연동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".NDGLApplication"
         android:allowBackup="true"
@@ -11,7 +13,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.NDGL">
+        android:theme="@style/Theme.NDGL"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/build-logic/src/main/kotlin/NDGLDataPlugin.kt
+++ b/build-logic/src/main/kotlin/NDGLDataPlugin.kt
@@ -24,6 +24,7 @@ class NDGLDataPlugin : Plugin<Project> {
         }
 
         dependencies {
+            "implementation"(project(":core:util"))
             "implementation"(libs.findLibrary("retrofit").get())
             "implementation"(libs.findLibrary("retrofit-kotlinx-serialization-json").get())
             "implementation"(libs.findLibrary("kotlinx-serialization-json").get())

--- a/data/auth/build.gradle.kts
+++ b/data/auth/build.gradle.kts
@@ -4,8 +4,19 @@ plugins {
 
 android {
     namespace = "com.yapp.ndgl.data.auth"
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    defaultConfig {
+        buildConfigField("String", "VERSION_NAME", "\"${Configuration.VERSION_NAME}\"")
+    }
 }
 
 dependencies {
+    implementation(project(":data:core"))
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
     implementation(libs.androidx.datastore)
 }

--- a/data/auth/src/main/java/com/yapp/ndgl/data/auth/local/LocalAuthDataSource.kt
+++ b/data/auth/src/main/java/com/yapp/ndgl/data/auth/local/LocalAuthDataSource.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.yapp.ndgl.data.auth.local.security.CryptoManager
 import com.yapp.ndgl.data.auth.local.util.handleException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -14,17 +15,18 @@ import javax.inject.Singleton
 @Singleton
 class LocalAuthDataSource @Inject constructor(
     private val dataStore: DataStore<Preferences>,
+    private val cryptoManager: CryptoManager,
 ) {
     private val accessToken: Flow<String> = dataStore.data
         .handleException()
         .map { preferences ->
-            preferences[ACCESS_TOKEN_KEY] ?: ""
+            cryptoManager.decrypt(preferences[ACCESS_TOKEN_KEY] ?: "")
         }
 
     private val uuid: Flow<String> = dataStore.data
         .handleException()
         .map { preferences ->
-            preferences[UUID_KEY] ?: ""
+            cryptoManager.decrypt(preferences[UUID_KEY] ?: "")
         }
 
     suspend fun getAccessToken(): String = accessToken.first()
@@ -33,13 +35,13 @@ class LocalAuthDataSource @Inject constructor(
 
     suspend fun setAccessToken(token: String) {
         dataStore.edit { preferences ->
-            preferences[ACCESS_TOKEN_KEY] = token
+            preferences[ACCESS_TOKEN_KEY] = cryptoManager.encrypt(token)
         }
     }
 
     suspend fun setUuid(uuid: String) {
         dataStore.edit { preferences ->
-            preferences[UUID_KEY] = uuid
+            preferences[UUID_KEY] = cryptoManager.encrypt(uuid)
         }
     }
 

--- a/data/auth/src/main/java/com/yapp/ndgl/data/auth/local/security/CryptoManager.kt
+++ b/data/auth/src/main/java/com/yapp/ndgl/data/auth/local/security/CryptoManager.kt
@@ -1,0 +1,84 @@
+package com.yapp.ndgl.data.auth.local.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import timber.log.Timber
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CryptoManager @Inject constructor() {
+    private val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER).apply {
+        load(null)
+    }
+
+    private fun getKey(): SecretKey {
+        return keyStore.getKey(KEY_ALIAS, null) as? SecretKey ?: createKey()
+    }
+
+    private fun createKey(): SecretKey =
+        KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            KEYSTORE_PROVIDER,
+        ).apply {
+            init(
+                KeyGenParameterSpec.Builder(
+                    KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(PADDING)
+                    .setUserAuthenticationRequired(false)
+                    .build(),
+            )
+        }.generateKey()
+
+    fun encrypt(plainText: String): String {
+        check(plainText.isNotEmpty()) { "Plain text is empty" }
+
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getKey())
+
+        val encryptedBytes = cipher.doFinal(plainText.toByteArray())
+        val combined = cipher.iv + encryptedBytes
+
+        return Base64.encodeToString(combined, Base64.NO_WRAP)
+    }
+
+    fun decrypt(encryptedText: String): String {
+        try {
+            check(encryptedText.isNotEmpty()) { "Encrypted text is empty" }
+
+            val combined = Base64.decode(encryptedText, Base64.NO_WRAP)
+            val iv = combined.copyOfRange(0, IV_SIZE)
+            val encryptedBytes = combined.copyOfRange(IV_SIZE, combined.size)
+
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            val spec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+            cipher.init(Cipher.DECRYPT_MODE, getKey(), spec)
+
+            val decryptedBytes = cipher.doFinal(encryptedBytes)
+            return String(decryptedBytes)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to decrypt")
+            return ""
+        }
+    }
+
+    companion object {
+        private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+        private const val KEY_ALIAS = "ndgl_encryption_key"
+        private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
+        private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_GCM
+        private const val PADDING = KeyProperties.ENCRYPTION_PADDING_NONE
+        private const val TRANSFORMATION = "$ALGORITHM/$BLOCK_MODE/$PADDING"
+        private const val IV_SIZE = 12
+        private const val GCM_TAG_LENGTH = 128
+    }
+}

--- a/data/auth/src/main/java/com/yapp/ndgl/data/auth/repository/AuthRepository.kt
+++ b/data/auth/src/main/java/com/yapp/ndgl/data/auth/repository/AuthRepository.kt
@@ -1,0 +1,64 @@
+package com.yapp.ndgl.data.auth.repository
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.messaging.FirebaseMessaging
+import com.yapp.ndgl.core.util.suspendRunCatching
+import com.yapp.ndgl.data.auth.BuildConfig
+import com.yapp.ndgl.data.auth.api.AuthApi
+import com.yapp.ndgl.data.auth.local.LocalAuthDataSource
+import com.yapp.ndgl.data.auth.model.AuthResponse
+import com.yapp.ndgl.data.auth.model.CreateUserRequest
+import com.yapp.ndgl.data.auth.model.LoginRequest
+import com.yapp.ndgl.data.auth.util.DeviceInfoUtil
+import com.yapp.ndgl.data.core.model.getData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthRepository @Inject constructor(
+    private val api: AuthApi,
+    private val localAuthDataSource: LocalAuthDataSource,
+) {
+    suspend fun initSession() {
+        val uuid = localAuthDataSource.getUuid()
+        val response = if (uuid.isNotEmpty()) {
+            suspendRunCatching {
+                login(uuid)
+            }.getOrElse {
+                localAuthDataSource.clearSession()
+                createUser()
+            }
+        } else {
+            createUser()
+        }
+
+        localAuthDataSource.setAccessToken(response.accessToken)
+        localAuthDataSource.setUuid(response.uuid)
+    }
+
+    private suspend fun createUser(): AuthResponse {
+        return api.createUser(
+            CreateUserRequest(
+                fcmToken = getFCMToken(),
+                deviceModel = DeviceInfoUtil.deviceModel,
+                deviceOs = DeviceInfoUtil.DEVICE_OS,
+                deviceOsVersion = DeviceInfoUtil.deviceOsVersion,
+                appVersion = BuildConfig.VERSION_NAME,
+            ),
+        ).getData()
+    }
+
+    private suspend fun login(uuid: String): AuthResponse {
+        return api.login(LoginRequest(uuid)).getData()
+    }
+
+    private suspend fun getFCMToken(): String = withContext(Dispatchers.IO) {
+        try {
+            Tasks.await(FirebaseMessaging.getInstance().token)
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to get FCM token", e)
+        }
+    }
+}

--- a/data/auth/src/main/java/com/yapp/ndgl/data/auth/util/DeviceInfoUtil.kt
+++ b/data/auth/src/main/java/com/yapp/ndgl/data/auth/util/DeviceInfoUtil.kt
@@ -1,0 +1,9 @@
+package com.yapp.ndgl.data.auth.util
+
+import android.os.Build
+
+object DeviceInfoUtil {
+    const val DEVICE_OS: String = "Android"
+    val deviceModel: String = Build.MODEL
+    val deviceOsVersion: String = Build.VERSION.RELEASE
+}

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -8,4 +8,5 @@ android {
 
 dependencies {
     implementation(project(":data:travel"))
+    implementation(project(":data:auth"))
 }

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeContract.kt
@@ -1,0 +1,13 @@
+package com.yapp.ndgl.feature.home
+
+import com.yapp.ui.base.UiIntent
+import com.yapp.ui.base.UiSideEffect
+import com.yapp.ui.base.UiState
+
+data class HomeState(
+    val isLoading: Boolean = false,
+) : UiState
+
+sealed interface HomeIntent : UiIntent
+
+sealed interface HomeSideEffect : UiSideEffect

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeContract.kt
@@ -1,8 +1,8 @@
 package com.yapp.ndgl.feature.home
 
-import com.yapp.ui.base.UiIntent
-import com.yapp.ui.base.UiSideEffect
-import com.yapp.ui.base.UiState
+import com.yapp.ndgl.core.base.UiIntent
+import com.yapp.ndgl.core.base.UiSideEffect
+import com.yapp.ndgl.core.base.UiState
 
 data class HomeState(
     val isLoading: Boolean = false,

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeViewModel.kt
@@ -1,9 +1,9 @@
 package com.yapp.ndgl.feature.home
 
 import androidx.lifecycle.viewModelScope
+import com.yapp.ndgl.core.base.BaseViewModel
 import com.yapp.ndgl.core.util.suspendRunCatching
 import com.yapp.ndgl.data.auth.repository.AuthRepository
-import com.yapp.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import timber.log.Timber

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/HomeViewModel.kt
@@ -1,8 +1,35 @@
 package com.yapp.ndgl.feature.home
 
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yapp.ndgl.core.util.suspendRunCatching
+import com.yapp.ndgl.data.auth.repository.AuthRepository
+import com.yapp.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class HomeViewModel @Inject constructor() : ViewModel()
+class HomeViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+) : BaseViewModel<HomeState, HomeIntent, HomeSideEffect>(
+    initialState = HomeState(),
+) {
+    init {
+        initSession()
+    }
+
+    override suspend fun handleIntent(intent: HomeIntent) {
+        TODO("Not yet implemented")
+    }
+
+    private fun initSession() = viewModelScope.launch {
+        suspendRunCatching {
+            authRepository.initSession()
+        }.onSuccess {
+            Timber.d("initSession() 성공")
+        }.onFailure {
+            Timber.e("initSession() 실패")
+        }
+    }
+}

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("ndgl.android.library")
-    id("org.jetbrains.kotlin.plugin.serialization")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {


### PR DESCRIPTION
개요
- 로그인 및 유저 생성 API 연동
---
### 변경사항
- AuthRepository 추가
- 로그인 API 연동
- 유저 생성 API 연동
- accessToken, uuid 암호화해서 저장(AES-GCM 방식)
---
- 로그인 화면이 따로 존재하지 않으므로 우선 HomeViewModel에서 로그인 로직을 추가했습니다. 추후에 온보딩이나 스플래시 화면이 추가된다면 호출 위치가 변경될 수 있을 것 같습니다.

### 테스트 체크 리스트
- [x] 로그인 API
- [x] 유저 생성 API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 화면 기능 추가 및 앱 시작 시 자동 세션 초기화 도입
  * 사용자 인증 흐름(회원 생성·로그인) 및 Firebase 메시징 연동 지원

* **보안 개선**
  * 로컬에 저장된 인증 토큰과 사용자 정보 암호화 적용
  * 인터넷 접근 권한 및 명시적 평문 허용(네트워크 정책) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->