### PR TITLE
[NDGL-65] NDGLNavigationBar의 Trailing 아이콘이 없을 때 타이틀이 중앙에 정렬되지 않는 이슈 수정

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git add:*)",
-      "Bash(git rebase:*)",
-      "Bash(git fetch:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ render.experimental.xml
 # Google Services (e.g. APIs or Firebase)
 google-services.json
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # Android Profiling
 *.hprof
 

--- a/core/ui/src/main/java/com/yapp/ndgl/core/ui/designsystem/NDGLNavigationBar.kt
+++ b/core/ui/src/main/java/com/yapp/ndgl/core/ui/designsystem/NDGLNavigationBar.kt
@@ -3,6 +3,7 @@ package com.yapp.ndgl.core.ui.designsystem
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -45,8 +46,8 @@ fun NDGLNavigationBar(
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp)
-            .padding(horizontal = 24.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+            .padding(horizontal = 24.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         leadingIcon?.let { icon ->
@@ -69,8 +70,10 @@ fun NDGLNavigationBar(
             )
         } ?: Spacer(modifier = Modifier.weight(1f))
 
-        trailingContents?.let { contents ->
-            contents()
+        if (trailingContents != null) {
+            trailingContents()
+        } else {
+            Box(modifier = Modifier.size(40.dp))
         }
     }
 }
@@ -84,10 +87,11 @@ fun NDGLNavigationIcon(
         imageVector = ImageVector.vectorResource(icon),
         contentDescription = null,
         modifier = Modifier
-            .size(28.dp)
+            .size(40.dp)
             .clip(CircleShape)
-            .clickable(onClick = onClick),
-        tint = NDGLTheme.colors.black700,
+            .clickable(onClick = onClick)
+            .padding(6.dp),
+        tint = NDGLTheme.colors.black600,
     )
 }
 
@@ -109,6 +113,36 @@ private fun NDGLNavigationBarCenterPreview() {
                     onClick = {},
                 )
             },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NDGLNavigationBarPreview() {
+    NDGLTheme {
+        NDGLNavigationBar(
+            textAlignType = NDGLNavigationBarAttr.TextAlignType.CENTER,
+            headline = "미리보기",
+            leadingIcon = R.drawable.ic_28_chevron_left,
+            trailingContents = {
+                NDGLNavigationIcon(
+                    icon = R.drawable.ic_28_search,
+                    onClick = {},
+                )
+            },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NDGLNavigationBarNoTrailingPreview() {
+    NDGLTheme {
+        NDGLNavigationBar(
+            textAlignType = NDGLNavigationBarAttr.TextAlignType.CENTER,
+            headline = "미리보기",
+            leadingIcon = R.drawable.ic_28_chevron_left,
         )
     }
 }


### PR DESCRIPTION
NDGLNavigationBar의 Trailing 아이콘이 없을 때 타이틀이 중앙에 정렬되지 않는 이슈 수정
클로드 로컬 설정 파일 제거 및 .gitignore 추가

---

### 연관 문서

- [네비게이션 바 이슈 수정 Task](https://ndglofficial.atlassian.net/jira/software/projects/NDGL/boards/1?selectedIssue=NDGL-65)

### 디자인

- [디자인 시스템 피그마](https://www.figma.com/design/z4YahfTF6uMPZ37JpUPT0p/Design-System_-YAPP-1%ED%8C%80-?node-id=223-942&m=dev)

### 변경사항

- TrailingIcon이 없을 경우 Box로 여백을 두어서 trailing icon 유무에 관계 없이 타이틀이 동일한 곳에 위치하도록 수정
- 터치 범위를 고려하여 간격 수정
- 아이콘 색상이 잘못 적용된 이슈 수정(700 -> 600)
- 클로드 로컬 설정 파일 제거 및 .gitignore 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 스타일
  * 네비게이션 바 세로 패딩을 12dp → 4dp, 가로 간격을 8dp → 4dp로 줄여 화면 공간 활용을 개선했습니다.
  * 네비게이션 아이콘의 고정 크기 규격을 변경하고 6dp 패딩을 추가했으며 색상을 진한 검정에서 조금 더 연한 톤으로 조정했습니다.
  * 트레일링 콘텐츠가 없을 때 40dp 자리표시자를 표시해 레이아웃 균형을 유지합니다.
* 문서
  * 트레일링 콘텐츠 유무를 보여주는 미리보기를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->