### PR TITLE
[NDGL-97] NDGLApp에서 Scaffold 제거

### DIFF
--- a/app/src/main/java/com/yapp/ndgl/ui/NDGLApp.kt
+++ b/app/src/main/java/com/yapp/ndgl/ui/NDGLApp.kt
@@ -3,7 +3,6 @@ package com.yapp.ndgl.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -30,21 +29,17 @@ fun NDGLApp() {
         remember(navigationState.currentKey) { navigationState.currentKey in navigationState.topLevelKeys }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Scaffold(
-            modifier = Modifier.fillMaxSize(),
-        ) { innerPadding ->
-            val entryProvider = entryProvider {
-                homeEntry(navigator, innerPadding)
-                travelEntry(navigator, innerPadding)
-                travelHelperEntry(navigator, innerPadding)
-            }
-
-            NavDisplay(
-                modifier = Modifier.fillMaxSize(),
-                onBack = navigator::goBack,
-                entries = navigationState.toEntries(entryProvider),
-            )
+        val entryProvider = entryProvider {
+            homeEntry(navigator)
+            travelEntry(navigator)
+            travelHelperEntry(navigator)
         }
+
+        NavDisplay(
+            modifier = Modifier.fillMaxSize(),
+            onBack = navigator::goBack,
+            entries = navigationState.toEntries(entryProvider),
+        )
 
         AnimatedVisibility(
             modifier = Modifier.align(Alignment.BottomCenter),

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeScreen.kt
@@ -25,11 +25,9 @@ import java.time.LocalDate
 @Composable
 internal fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel(),
-    innerPadding: PaddingValues,
 ) {
     val state by viewModel.collectAsState()
     HomeScreen(
-        modifier = Modifier.padding(innerPadding),
         state = state,
         onTabSelected = { index ->
             viewModel.onIntent(HomeIntent.SelectPopularTravelTab(index))
@@ -39,7 +37,6 @@ internal fun HomeRoute(
 
 @Composable
 private fun HomeScreen(
-    modifier: Modifier,
     state: HomeState = HomeState(),
     onTabSelected: (Int) -> Unit = {},
 ) {
@@ -64,7 +61,9 @@ private fun HomeScreen(
         },
     ) { innerPadding ->
         LazyColumn(
-            modifier = modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
             contentPadding = PaddingValues(
                 top = innerPadding.calculateTopPadding() + 20.dp,
                 bottom = 80.dp,
@@ -145,7 +144,6 @@ private fun HomeScreenPreview() {
 
     NDGLTheme {
         HomeScreen(
-            modifier = Modifier,
             state = HomeState(
                 userName = "유저123",
                 myTravel = HomeState.MyTravel.InProgress(

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/navigation/HomeEntry.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/navigation/HomeEntry.kt
@@ -1,14 +1,15 @@
 package com.yapp.ndgl.feature.home.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.yapp.ndgl.feature.home.main.HomeRoute
 import com.yapp.ndgl.navigation.Navigator
 import com.yapp.ndgl.navigation.Route
 
-fun EntryProviderScope<NavKey>.homeEntry(navigator: Navigator, innerPadding: PaddingValues) {
+fun EntryProviderScope<NavKey>.homeEntry(
+    navigator: Navigator,
+) {
     entry<Route.Home> {
-        HomeRoute(innerPadding = innerPadding)
+        HomeRoute()
     }
 }

--- a/feature/travel-helper/src/main/java/com/yapp/ndgl/feature/travelhelper/navigation/TravelHelperEntry.kt
+++ b/feature/travel-helper/src/main/java/com/yapp/ndgl/feature/travelhelper/navigation/TravelHelperEntry.kt
@@ -1,14 +1,13 @@
 package com.yapp.ndgl.feature.travelhelper.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.yapp.ndgl.feature.travelhelper.TravelHelperRoute
 import com.yapp.ndgl.navigation.Navigator
 import com.yapp.ndgl.navigation.Route
 
-fun EntryProviderScope<NavKey>.travelHelperEntry(navigator: Navigator, innerPadding: PaddingValues) {
+fun EntryProviderScope<NavKey>.travelHelperEntry(navigator: Navigator) {
     entry<Route.TravelHelper> {
-        TravelHelperRoute(innerPadding = innerPadding)
+        TravelHelperRoute()
     }
 }

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/datepicker/DatePickerScreen.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/datepicker/DatePickerScreen.kt
@@ -31,7 +31,7 @@ import kotlinx.datetime.LocalDate
 internal fun DatePickerRoute(
     viewModel: DatePickerViewModel = hiltViewModel(),
     navigateBack: () -> Unit = {},
-    innerPadding: PaddingValues,
+    innerPadding: PaddingValues = PaddingValues(),
 ) {
     val state by viewModel.collectAsState()
 

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/navigation/TravelEntry.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/navigation/TravelEntry.kt
@@ -1,6 +1,5 @@
 package com.yapp.ndgl.feature.travel.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
@@ -16,7 +15,7 @@ import com.yapp.ndgl.feature.travel.traveldetail.TravelDetailViewModel
 import com.yapp.ndgl.navigation.Navigator
 import com.yapp.ndgl.navigation.Route
 
-fun EntryProviderScope<NavKey>.travelEntry(navigator: Navigator, innerPadding: PaddingValues) {
+fun EntryProviderScope<NavKey>.travelEntry(navigator: Navigator) {
     entry<Route.Travel> {
         TravelRoute(
             navigateToFollowTravel = { travelId ->
@@ -25,7 +24,6 @@ fun EntryProviderScope<NavKey>.travelEntry(navigator: Navigator, innerPadding: P
             navigateToTravelDetail = { travelId ->
                 navigator.navigate(Route.TravelDetail(travelId))
             },
-            innerPadding = innerPadding,
         )
     }
     entry<Route.FollowTravel> { route ->
@@ -61,7 +59,6 @@ fun EntryProviderScope<NavKey>.travelEntry(navigator: Navigator, innerPadding: P
             }
         PlaceDetailRoute(
             viewModel = viewModel,
-            innerPadding = innerPadding,
             navigateBack = { navigator.goBack() },
         )
     }
@@ -73,7 +70,6 @@ fun EntryProviderScope<NavKey>.travelEntry(navigator: Navigator, innerPadding: P
         DatePickerRoute(
             viewModel = viewModel,
             navigateBack = { navigator.goBack() },
-            innerPadding = innerPadding,
         )
     }
 }

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/placedetail/PlaceDetailScreen.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/placedetail/PlaceDetailScreen.kt
@@ -56,7 +56,7 @@ import com.yapp.ndgl.feature.travel.placedetail.component.PlacePhotoTab
 @Composable
 internal fun PlaceDetailRoute(
     viewModel: PlaceDetailViewModel = hiltViewModel(),
-    innerPadding: PaddingValues,
+    innerPadding: PaddingValues = PaddingValues(),
     navigateBack: () -> Unit,
 ) {
     val state by viewModel.collectAsState()


### PR DESCRIPTION
[NDGL-97] NDGLApp에서 Scaffold 제거

---

### 연관 문서

- [NDGL-97 Task](https://ndglofficial.atlassian.net/jira/software/projects/NDGL/boards/1?jql=assignee%20%3D%206251b879f813eb00692fa567&selectedIssue=NDGL-97)


### 변경사항

- NDGLApp에서 Scaffold 제거
```
결론적으로 NDGLApp에 적용된 Scaffold를 제거하고,
각 화면별로 Scaffold를 적용하는 방향으로 가는 게 어떨까 싶습니다

일단 NDGLApp의 Scaffold는  topBar/bottomBar가 없는 inset 처리용 껍데기로 사용되고 있습니다
BottomNavigationBar도 Scaffold 밖의 Box + AnimatedVisibility로 처리하고 있기 때문에 padding 충돌 위험이 없습니다

저희 앱 구조상 화면별로 독립적인 TopBar를 사용하고 있습니다
HomeScreen은 검색/설정 아이콘이 있는 탑바를 사용하고,
검색 화면은 서치바가 포함된 탑바를 사용하고 있으며,
상세 화면 역시 다른 형태의 화면을 가지고 있습니다
이를 StickyHeader로 대체할 경우, Status bar inset처리나 elevation 등의 로직을 직접 관리해야 하는 부담이 생깁니다

화면별로 Scaffold를 적용할 경우, SnackBarHostState 역시 화면 별로 독립적으로 관리할 수 있어 상태 공유 문제를 방지할 수 있습니다
(Toast와 다르게 SnackBar의 경우 화면에 종속되어 있어 화면을 벗어날 경우 스낵바라 화면과 함께 사라지는 동작을 기본으로 하고 있는데, 요 상태 적용도 용이해집니다)

참고로 nowinandroid 프로젝트에서는 단일 Scaffold를 사용하지만, 모든 탑 레벨 화면의 탑바가 거의 동일하고, 제목만 변경하는 수준이기 때문에 가능한 구조입니다
https://github.com/android/nowinandroid/blob/main/app/src/main/kotlin/com/google/samples/apps/nowinandroid/ui/NiaApp.kt
https://github.com/android/nowinandroid/issues/1943

화면마다 topBar 구성이 달라지는 경우에는 App 레벨 Scaffold에 조건 분기가 많아져 오히려 복잡해질 수 있습니다
StickyHeader로 처리할 경우 위에서 말씀드린 문제가 발생하고,
저희가 적용하는 네비게이션바가 사실상 Scaffold의 Topbar의 설계 의도에 정확히 적용되는 케이스라, 별도의 비용을 들여 관리할 필요는 없다고 생각합니다!

지금 당장 모든 화면에 적용하자는 취지는 아니고,
HomeScreen이나 이후 붙어지는 화면에 대해서는 별도로 적용하도록 차차 수정해나갔으면 합니다!
```

### 테스트 체크 리스트

- [x] 빌드 테스트


[NDGL-97]: https://ndglofficial.atlassian.net/browse/NDGL-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 네비게이션 시스템의 내부 구조를 단순화하여 애플리케이션 안정성 향상
  * 화면 간 패딩 및 레이아웃 처리 방식을 최적화하여 개발 효율성 개선
  * 코드베이스의 복잡도 감소로 유지보수 비용 절감

<!-- end of auto-generated comment: release notes by coderabbit.ai -->