### PR TITLE
[NDGL-102] 앱 설정 기능 구현

### DIFF
--- a/data/auth/src/main/java/com/yapp/ndgl/data/auth/repository/AuthRepository.kt
+++ b/data/auth/src/main/java/com/yapp/ndgl/data/auth/repository/AuthRepository.kt
@@ -22,7 +22,7 @@ class AuthRepository @Inject constructor(
     private val localAuthDataSource: LocalAuthDataSource,
 ) {
     suspend fun initSession(): Boolean {
-        val uuid = localAuthDataSource.getUuid()
+        val uuid = getIdentifierCode()
         var isFirstUser = false
         val response = if (uuid.isNotEmpty()) {
             suspendRunCatching {
@@ -65,4 +65,6 @@ class AuthRepository @Inject constructor(
             throw IllegalStateException("Failed to get FCM token", e)
         }
     }
+
+    suspend fun getIdentifierCode(): String = localAuthDataSource.getUuid()
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -7,5 +7,6 @@ android {
 }
 
 dependencies {
+    implementation(project(":data:auth"))
     implementation(project(":data:travel"))
 }

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeContract.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeContract.kt
@@ -64,6 +64,7 @@ data class HomeState(
 
 sealed interface HomeIntent : UiIntent {
     data object ClickSearchTravelTemplate : HomeIntent
+    data object ClickSettings : HomeIntent
     data class SelectPopularTravelTab(val index: Int) : HomeIntent
     data class ClickTravel(val travelId: Long) : HomeIntent
     data object ClickTravelMore : HomeIntent
@@ -71,6 +72,7 @@ sealed interface HomeIntent : UiIntent {
 
 sealed interface HomeSideEffect : UiSideEffect {
     data object NavigateToSearchTravelTemplate : HomeSideEffect
+    data object NavigateToSettings : HomeSideEffect
     data class NavigateToFollowTravel(val travelId: Long, val days: Int) : HomeSideEffect
     data object NavigateToTravelMore : HomeSideEffect
 }

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeScreen.kt
@@ -29,6 +29,7 @@ import java.time.LocalDate
 internal fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel(),
     navigateToTemplateSearch: () -> Unit,
+    navigateToSettings: () -> Unit,
     navigateToFollowTravel: (Long, Int) -> Unit,
     navigateToPopularTravelList: () -> Unit,
 ) {
@@ -38,6 +39,9 @@ internal fun HomeRoute(
         state = state,
         onSearchClick = {
             viewModel.onIntent(HomeIntent.ClickSearchTravelTemplate)
+        },
+        onSettingsClick = {
+            viewModel.onIntent(HomeIntent.ClickSettings)
         },
         onTabSelected = { index ->
             viewModel.onIntent(HomeIntent.SelectPopularTravelTab(index))
@@ -53,6 +57,7 @@ internal fun HomeRoute(
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             HomeSideEffect.NavigateToSearchTravelTemplate -> navigateToTemplateSearch()
+            HomeSideEffect.NavigateToSettings -> navigateToSettings()
             is HomeSideEffect.NavigateToFollowTravel -> navigateToFollowTravel(sideEffect.travelId, sideEffect.days)
             HomeSideEffect.NavigateToTravelMore -> navigateToPopularTravelList()
         }
@@ -63,6 +68,7 @@ internal fun HomeRoute(
 private fun HomeScreen(
     state: HomeState,
     onSearchClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     onTabSelected: (Int) -> Unit,
     onTravelClick: (Long) -> Unit,
     onTravelMoreClick: () -> Unit,
@@ -82,7 +88,7 @@ private fun HomeScreen(
                     )
                     NDGLNavigationIcon(
                         icon = R.drawable.ic_28_settings,
-                        onClick = { /* FIXME: 설정 */ },
+                        onClick = onSettingsClick,
                     )
                 },
             )
@@ -204,6 +210,7 @@ private fun HomeScreenPreview() {
                 allPopularTravels = sampleTravels,
             ),
             onSearchClick = {},
+            onSettingsClick = {},
             onTabSelected = {},
             onTravelClick = {},
             onTravelMoreClick = {},

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/HomeViewModel.kt
@@ -173,11 +173,10 @@ class HomeViewModel @Inject constructor(
     override suspend fun handleIntent(intent: HomeIntent) {
         when (intent) {
             HomeIntent.ClickSearchTravelTemplate -> postNavigateToSearchTravelTemplate()
-
+            HomeIntent.ClickSettings -> postNavigateToSettings()
             is HomeIntent.SelectPopularTravelTab -> {
                 reduce { copy(popularTravelSelectedTabIndex = intent.index) }
             }
-
             is HomeIntent.ClickTravel -> postNavigateToTravelTemplate(travelId = intent.travelId)
             HomeIntent.ClickTravelMore -> postNavigateToTravelMore()
         }
@@ -185,6 +184,10 @@ class HomeViewModel @Inject constructor(
 
     private fun postNavigateToSearchTravelTemplate() {
         postSideEffect(HomeSideEffect.NavigateToSearchTravelTemplate)
+    }
+
+    private fun postNavigateToSettings() {
+        postSideEffect(HomeSideEffect.NavigateToSettings)
     }
 
     private fun postNavigateToTravelTemplate(travelId: Long) {

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/navigation/HomeEntry.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/navigation/HomeEntry.kt
@@ -5,6 +5,7 @@ import androidx.navigation3.runtime.NavKey
 import com.yapp.ndgl.feature.home.main.HomeRoute
 import com.yapp.ndgl.feature.home.popular.PopularTravelListRoute
 import com.yapp.ndgl.feature.home.search.TemplateSearchRoute
+import com.yapp.ndgl.feature.home.settings.SettingsRoute
 import com.yapp.ndgl.navigation.Navigator
 import com.yapp.ndgl.navigation.Route
 
@@ -15,6 +16,9 @@ fun EntryProviderScope<NavKey>.homeEntry(
         HomeRoute(
             navigateToTemplateSearch = {
                 navigator.navigate(Route.TemplateSearch)
+            },
+            navigateToSettings = {
+                navigator.navigate(Route.Settings)
             },
             navigateToFollowTravel = { travelId, days ->
                 navigator.navigate(Route.FollowTravel(travelId = travelId, days = days))
@@ -44,6 +48,13 @@ fun EntryProviderScope<NavKey>.homeEntry(
             },
             navigateToFollowTravel = { travelId, days ->
                 navigator.navigate(Route.FollowTravel(travelId = travelId, days = days))
+            },
+        )
+    }
+    entry<Route.Settings> {
+        SettingsRoute(
+            goBack = {
+                navigator.goBack()
             },
         )
     }

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/settings/SettingsContract.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/settings/SettingsContract.kt
@@ -1,0 +1,70 @@
+package com.yapp.ndgl.feature.home.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import com.yapp.ndgl.core.base.UiIntent
+import com.yapp.ndgl.core.base.UiSideEffect
+import com.yapp.ndgl.core.base.UiState
+import com.yapp.ndgl.feature.home.R
+import com.yapp.ndgl.feature.home.settings.SettingsState.UrlMenu
+import kotlinx.collections.immutable.ImmutableList
+
+@Immutable
+data class SettingsState(
+    val menuItems: ImmutableList<SettingsMenu>,
+) : UiState {
+    @Stable
+    sealed interface SettingsMenu {
+        @get:StringRes
+        val labelRes: Int
+
+        data class OpenUrl(
+            val menu: UrlMenu,
+        ) : SettingsMenu {
+            override val labelRes = menu.labelRes
+        }
+
+        data object CopyIdentifierCode : SettingsMenu {
+            override val labelRes = R.string.home_settings_identification_code
+        }
+
+        data class AppVersion(
+            val versionName: String,
+        ) : SettingsMenu {
+            override val labelRes = R.string.home_settings_version_info
+        }
+    }
+
+    enum class UrlMenu(
+        @get:StringRes val labelRes: Int,
+        val url: String,
+    ) {
+        FAQ(
+            labelRes = R.string.home_settings_faq,
+            url = "https://repeated-tapir-33f.notion.site/FAQ-30ccbdc5a38380d6af4af7b7c412921e?source=copy_link",
+        ),
+        RECOMMEND_LINK(
+            labelRes = R.string.home_settings_recommend_link,
+            url = "https://forms.gle/3q1uhQVeeKRrz11y5",
+        ),
+        TERMS_OF_SERVICE(
+            labelRes = R.string.home_settings_terms_of_service,
+            url = "https://repeated-tapir-33f.notion.site/2c8cbdc5a3838070a8d8ccdcd0631c9a?source=copy_link",
+        ),
+        PRIVACY_POLICY(
+            labelRes = R.string.home_settings_privacy_policy,
+            url = "https://repeated-tapir-33f.notion.site/30ccbdc5a38380e3a50ace64a9b0f398?source=copy_link",
+        ),
+    }
+}
+
+sealed interface SettingsIntent : UiIntent {
+    data class ClickUrlMenu(val menu: UrlMenu) : SettingsIntent
+    data object ClickCopyIdentifierCodeMenu : SettingsIntent
+}
+
+sealed interface SettingsSideEffect : UiSideEffect {
+    data class OpenUrl(val url: String) : SettingsSideEffect
+    data class CopyIdentifierCode(val code: String) : SettingsSideEffect
+}

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/settings/SettingsScreen.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/settings/SettingsScreen.kt
@@ -1,0 +1,174 @@
+package com.yapp.ndgl.feature.home.settings
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.yapp.ndgl.core.ui.designsystem.NDGLNavigationBar
+import com.yapp.ndgl.core.ui.designsystem.NDGLNavigationBarAttr
+import com.yapp.ndgl.core.ui.theme.NDGLTheme
+import com.yapp.ndgl.core.ui.util.launchBrowser
+import com.yapp.ndgl.feature.home.R
+import com.yapp.ndgl.feature.home.settings.SettingsState.SettingsMenu
+import kotlinx.collections.immutable.ImmutableList
+import com.yapp.ndgl.core.ui.R as CoreR
+
+@Composable
+internal fun SettingsRoute(
+    viewModel: SettingsViewModel = hiltViewModel(),
+    goBack: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    val state by viewModel.collectAsState()
+
+    SettingsScreen(
+        menuItems = state.menuItems,
+        goBack = goBack,
+        onUrlItemClick = {
+            viewModel.onIntent(SettingsIntent.ClickUrlMenu(it))
+        },
+        onCopyIdentifierCodeClick = {
+            viewModel.onIntent(SettingsIntent.ClickCopyIdentifierCodeMenu)
+        },
+    )
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is SettingsSideEffect.OpenUrl -> context.launchBrowser(sideEffect.url)
+            is SettingsSideEffect.CopyIdentifierCode -> {
+                val clipboard = context.getSystemService(ClipboardManager::class.java)
+                val clip = ClipData.newPlainText(
+                    context.getString(R.string.home_settings_identification_code),
+                    sideEffect.code,
+                )
+                clipboard?.setPrimaryClip(clip)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsScreen(
+    menuItems: ImmutableList<SettingsMenu>,
+    goBack: () -> Unit,
+    onUrlItemClick: (SettingsState.UrlMenu) -> Unit,
+    onCopyIdentifierCodeClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            NDGLNavigationBar(
+                textAlignType = NDGLNavigationBarAttr.TextAlignType.CENTER,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = NDGLTheme.colors.white)
+                    .statusBarsPadding(),
+                headline = stringResource(R.string.home_settings_title),
+                leadingIcon = CoreR.drawable.ic_28_chevron_left,
+                onLeadingIconClick = goBack,
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(24.dp),
+        ) {
+            items(
+                items = menuItems,
+                key = { item -> item.labelRes },
+            ) { item ->
+                when (item) {
+                    is SettingsMenu.OpenUrl -> SettingsMenuItem(
+                        text = stringResource(item.labelRes),
+                        onClick = { onUrlItemClick(item.menu) },
+                    )
+
+                    SettingsMenu.CopyIdentifierCode -> SettingsMenuItem(
+                        text = stringResource(item.labelRes),
+                        onClick = onCopyIdentifierCodeClick,
+                    )
+
+                    is SettingsMenu.AppVersion -> VersionItem(versionName = item.versionName)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsMenuItem(
+    text: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = NDGLTheme.typography.bodyLgRegular,
+            color = NDGLTheme.colors.black700,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = ImageVector.vectorResource(CoreR.drawable.ic_24_chevron_right),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = NDGLTheme.colors.black600,
+        )
+    }
+    HorizontalDivider(color = NDGLTheme.colors.black50)
+}
+
+@Composable
+private fun VersionItem(
+    versionName: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.home_settings_version_info),
+            style = NDGLTheme.typography.bodyLgRegular,
+            color = NDGLTheme.colors.black700,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = versionName,
+            style = NDGLTheme.typography.bodyLgRegular,
+            color = NDGLTheme.colors.black400,
+        )
+    }
+    HorizontalDivider(color = NDGLTheme.colors.black50)
+}

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/settings/SettingsViewModel.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/settings/SettingsViewModel.kt
@@ -1,0 +1,46 @@
+package com.yapp.ndgl.feature.home.settings
+
+import androidx.lifecycle.viewModelScope
+import com.yapp.ndgl.core.base.BaseViewModel
+import com.yapp.ndgl.data.auth.repository.AuthRepository
+import com.yapp.ndgl.feature.home.settings.SettingsState.SettingsMenu
+import com.yapp.ndgl.feature.home.util.AppVersionProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val appVersionProvider: AppVersionProvider,
+    private val authRepository: AuthRepository,
+) : BaseViewModel<SettingsState, SettingsIntent, SettingsSideEffect>(
+    initialState = SettingsState(
+        menuItems = persistentListOf(
+            SettingsMenu.OpenUrl(SettingsState.UrlMenu.FAQ),
+            SettingsMenu.OpenUrl(SettingsState.UrlMenu.RECOMMEND_LINK),
+            SettingsMenu.CopyIdentifierCode,
+            SettingsMenu.OpenUrl(SettingsState.UrlMenu.TERMS_OF_SERVICE),
+            SettingsMenu.OpenUrl(SettingsState.UrlMenu.PRIVACY_POLICY),
+            SettingsMenu.AppVersion(appVersionProvider.getAppVersion()),
+        ),
+    ),
+) {
+    override suspend fun handleIntent(intent: SettingsIntent) {
+        when (intent) {
+            is SettingsIntent.ClickUrlMenu -> postOpenUrl(intent.menu)
+            SettingsIntent.ClickCopyIdentifierCodeMenu -> postCopyIdentifierCode()
+        }
+    }
+
+    private fun postOpenUrl(menu: SettingsState.UrlMenu) {
+        postSideEffect(SettingsSideEffect.OpenUrl(menu.url))
+    }
+
+    private fun postCopyIdentifierCode() {
+        viewModelScope.launch {
+            val uuid = authRepository.getIdentifierCode()
+            postSideEffect(SettingsSideEffect.CopyIdentifierCode(uuid))
+        }
+    }
+}

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/util/AppVersionProvider.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/util/AppVersionProvider.kt
@@ -1,0 +1,15 @@
+package com.yapp.ndgl.feature.home.util
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class AppVersionProvider @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    fun getAppVersion(): String {
+        return runCatching {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
+        }.getOrDefault("")
+    }
+}

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Common -->
+    <string name="home_common_dot_separator">•</string>
+
     <!-- MyTravelCardSection -->
     <string name="home_my_travel_card_empty_title">아직 등록된 여행지가 없어요</string>
     <string name="home_my_travel_card_empty_description">새 여행 일정을 만들어 보세요!</string>
@@ -26,6 +29,12 @@
     <string name="home_template_search_error_title">정보를 불러올 수 없어요</string>
     <string name="home_template_search_error_description">인터넷 연결 확인 후 다시 시도해 주세요</string>
 
-    <!-- Common -->
-    <string name="home_common_dot_separator">•</string>
+    <!-- Settings -->
+    <string name="home_settings_title">설정</string>
+    <string name="home_settings_faq">FAQ</string>
+    <string name="home_settings_recommend_link">콘텐츠 추천 링크 넣기</string>
+    <string name="home_settings_identification_code">내 식별코드</string>
+    <string name="home_settings_terms_of_service">서비스 약관</string>
+    <string name="home_settings_privacy_policy">개인정보처리 방침</string>
+    <string name="home_settings_version_info">버전 정보</string>
 </resources>

--- a/feature/splash/src/main/java/com/yapp/ndgl/feature/splash/SplashContract.kt
+++ b/feature/splash/src/main/java/com/yapp/ndgl/feature/splash/SplashContract.kt
@@ -1,9 +1,12 @@
 package com.yapp.ndgl.feature.splash
 
+import com.yapp.ndgl.core.base.UiIntent
 import com.yapp.ndgl.core.base.UiSideEffect
 import com.yapp.ndgl.core.base.UiState
 
 class SplashState : UiState
+
+sealed interface SplashUiIntent : UiIntent
 
 sealed interface SplashSideEffect : UiSideEffect {
     data class NavigateToHome(val isFirstUser: Boolean) : SplashSideEffect

--- a/feature/splash/src/main/java/com/yapp/ndgl/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/yapp/ndgl/feature/splash/SplashViewModel.kt
@@ -2,7 +2,6 @@ package com.yapp.ndgl.feature.splash
 
 import androidx.lifecycle.viewModelScope
 import com.yapp.ndgl.core.base.BaseViewModel
-import com.yapp.ndgl.core.base.UiIntent
 import com.yapp.ndgl.core.util.suspendRunCatching
 import com.yapp.ndgl.data.auth.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,7 +11,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-) : BaseViewModel<SplashState, UiIntent, SplashSideEffect>(
+) : BaseViewModel<SplashState, SplashUiIntent, SplashSideEffect>(
     initialState = SplashState(),
 ) {
     init {
@@ -29,7 +28,5 @@ class SplashViewModel @Inject constructor(
         }
     }
 
-    override suspend fun handleIntent(intent: UiIntent) {
-        // Splash에 따로 intent 존재하지 않음
-    }
+    override suspend fun handleIntent(intent: SplashUiIntent) = Unit
 }

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/mytravel/MyTravelContract.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/mytravel/MyTravelContract.kt
@@ -80,6 +80,7 @@ data class MyTravelState(
 
 sealed interface MyTravelIntent : UiIntent {
     data object ClickSearchTravelTemplate : MyTravelIntent
+    data object ClickSettings : MyTravelIntent
     data class ClickTravel(val travelId: Long) : MyTravelIntent
     data class ClickTravelDetail(val travelId: Long) : MyTravelIntent
     data class ClickPlaceDetail(val placeId: String) : MyTravelIntent
@@ -88,6 +89,7 @@ sealed interface MyTravelIntent : UiIntent {
 
 sealed interface MyTravelSideEffect : UiSideEffect {
     data object NavigateToSearchTravelTemplate : MyTravelSideEffect
+    data object NavigateToSettings : MyTravelSideEffect
     data class NavigateToFollowTravel(val travelId: Long, val days: Int) : MyTravelSideEffect
     data class NavigateToTravelDetail(val travelId: Long) : MyTravelSideEffect
     data class NavigateToTravelPlace(val placeId: String) : MyTravelSideEffect

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/mytravel/MyTravelScreen.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/mytravel/MyTravelScreen.kt
@@ -26,6 +26,7 @@ import com.yapp.ndgl.core.ui.theme.NDGLTheme
 internal fun MyTravelRoute(
     viewModel: MyTravelViewModel = hiltViewModel(),
     navigateToTemplateSearch: () -> Unit,
+    navigateToSettings: () -> Unit,
     navigateToFollowTravel: (Long, Int) -> Unit,
     navigateToTravelDetail: (Long) -> Unit,
     navigateToTravelPlace: (String) -> Unit,
@@ -37,6 +38,9 @@ internal fun MyTravelRoute(
         state = state,
         onSearchClick = {
             viewModel.onIntent(MyTravelIntent.ClickSearchTravelTemplate)
+        },
+        onSettingsClick = {
+            viewModel.onIntent(MyTravelIntent.ClickSettings)
         },
         onTravelClick = { travelId ->
             viewModel.onIntent(MyTravelIntent.ClickTravelDetail(travelId = travelId))
@@ -55,6 +59,8 @@ internal fun MyTravelRoute(
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             MyTravelSideEffect.NavigateToSearchTravelTemplate -> navigateToTemplateSearch()
+
+            MyTravelSideEffect.NavigateToSettings -> navigateToSettings()
 
             is MyTravelSideEffect.NavigateToFollowTravel -> navigateToFollowTravel(
                 sideEffect.travelId,
@@ -78,6 +84,7 @@ internal fun MyTravelRoute(
 private fun MyTravelScreen(
     state: MyTravelState,
     onSearchClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     onTravelClick: (Long) -> Unit,
     onPlaceClick: (String) -> Unit,
     onNewTravelFindClick: () -> Unit,
@@ -99,7 +106,7 @@ private fun MyTravelScreen(
                     )
                     NDGLNavigationIcon(
                         icon = R.drawable.ic_28_settings,
-                        onClick = { /* FIXME: 설정 */ },
+                        onClick = onSettingsClick,
                     )
                 },
             )
@@ -152,6 +159,7 @@ private fun MyTravelScreenPreview() {
         MyTravelScreen(
             state = MyTravelState(),
             onSearchClick = {},
+            onSettingsClick = {},
             onTravelClick = {},
             onPlaceClick = {},
             onNewTravelFindClick = {},

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/mytravel/MyTravelViewModel.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/mytravel/MyTravelViewModel.kt
@@ -131,6 +131,7 @@ class MyTravelViewModel @Inject constructor(
     override suspend fun handleIntent(intent: MyTravelIntent) {
         when (intent) {
             MyTravelIntent.ClickSearchTravelTemplate -> postNavigateToSearchTravelTemplate()
+            MyTravelIntent.ClickSettings -> postNavigateToSettings()
             is MyTravelIntent.ClickTravel -> postNavigateToFollowTravel(travelId = intent.travelId)
             is MyTravelIntent.ClickTravelDetail -> postNavigateToTravelDetail(travelId = intent.travelId)
             is MyTravelIntent.ClickPlaceDetail -> postNavigateToPlaceDetail(placeId = intent.placeId)
@@ -140,6 +141,10 @@ class MyTravelViewModel @Inject constructor(
 
     private fun postNavigateToSearchTravelTemplate() {
         postSideEffect(MyTravelSideEffect.NavigateToSearchTravelTemplate)
+    }
+
+    private fun postNavigateToSettings() {
+        postSideEffect(MyTravelSideEffect.NavigateToSettings)
     }
 
     private fun postNavigateToFollowTravel(travelId: Long, days: Int = 1) {

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/navigation/TravelEntry.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/navigation/TravelEntry.kt
@@ -30,6 +30,9 @@ fun EntryProviderScope<NavKey>.travelEntry(navigator: Navigator) {
             navigateToTemplateSearch = {
                 navigator.navigate(Route.TemplateSearch)
             },
+            navigateToSettings = {
+                navigator.navigate(Route.Settings)
+            },
             navigateToFollowTravel = { travelId, days ->
                 navigator.navigate(Route.FollowTravel(travelId, days))
             },

--- a/navigation/src/main/java/com/yapp/ndgl/navigation/Route.kt
+++ b/navigation/src/main/java/com/yapp/ndgl/navigation/Route.kt
@@ -20,6 +20,9 @@ sealed interface Route : NavKey {
     data object PopularTravelList : Route
 
     @Serializable
+    data object Settings : Route
+
+    @Serializable
     data object Travel : Route
 
     @Serializable


### PR DESCRIPTION
앱 설정 기능 구현

---

### 연관 문서

- [앱 설정 기능 구현 Task](https://ndglofficial.atlassian.net/jira/software/projects/NDGL/boards/1?selectedIssue=NDGL-102)

### 디자인

- [앱 설정 페이지 피그마](https://www.figma.com/design/qHn9o58ENLeHjiBWNuZFJx/Design_-YAPP-1%ED%8C%80-?node-id=2054-12967&m=dev)

### 스크린샷 (Optional)

| 스크린샷 | 스크린샷 |
|-------|-------|
| <img width="458" height="992" alt="image" src="https://github.com/user-attachments/assets/71bed7da-9566-4099-9e22-587d84b4fcd5" /> |       |

### 변경사항

- Splash 리팩토링
  - UiIntent 대신 SplashUiIntent sealed interface 도입으로 타입 안전성 확보
  - handleIntent 불필요한 주석 제거
- 설정 화면
  - SettingsContract: 메뉴 항목을 SettingsMenu sealed interface로 타입 분리
    - OpenUrl: FAQ, 콘텐츠 추천 링크, 서비스 약관, 개인정보처리방침 → 외부 브라우저 오픈
    - CopyIdentifierCode: 내 식별코드 → 클립보드 복사
    - AppVersion: 버전 정보 표시 (클릭 불가)
  - SettingsViewModel: AppVersionProvider 주입으로 앱 버전 조회를 Compose 외부로 분리
  - AuthRepository.getIdentifierCode() 추가

### 테스트 체크 리스트

- [x] FAQ
- [x] 콘텐츠 추천 링크 넣기
- [x] 내 식별코드
- [x] 서비스 약관
- [x] 개인정보 처리 방침
- [x] 버전 정보


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 화면 추가: 자주 묻는 질문, 추천 링크, 이용약관, 개인정보 보호정책, 앱 버전 정보 메뉴 포함
  * 홈 및 여행 화면에서 설정 화면으로 이동할 수 있는 네비게이션 아이콘 추가
  * 설정 화면에서 식별 코드 복사 기능 추가

* **리팩토링**
  * 인증 저장소 공개 API 추가로 식별 코드 접근 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->