### PR TITLE
[NDGL-125] chore: NDGLChipTab을 LazyRow로 변경 및 contentPadding 적용

### DIFF
--- a/core/ui/src/main/java/com/yapp/ndgl/core/ui/designsystem/NDGLChipTab.kt
+++ b/core/ui/src/main/java/com/yapp/ndgl/core/ui/designsystem/NDGLChipTab.kt
@@ -4,13 +4,14 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -45,14 +46,17 @@ fun NDGLChipTab(
     selectedIndex: Int,
     onTabSelected: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
-    val scrollState = rememberScrollState()
-
-    Row(
-        modifier = modifier.horizontalScroll(scrollState),
+    LazyRow(
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = contentPadding,
     ) {
-        tabs.forEachIndexed { index, tab ->
+        itemsIndexed(
+            items = tabs,
+            key = { index, tab -> "${index}_${tab.tag}" },
+        ) { index, tab ->
             NDGLChipTabItem(
                 isSelected = index == selectedIndex,
                 name = tab.name,

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/PopularTravelSection.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/main/PopularTravelSection.kt
@@ -104,7 +104,8 @@ private fun HorizontalCardSection(
             }.toPersistentList(),
             selectedIndex = selectedTabIndex,
             onTabSelected = onTabSelected,
-            modifier = Modifier.padding(start = 24.dp),
+            modifier = Modifier,
+            contentPadding = PaddingValues(horizontal = 24.dp),
         )
 
         if (columns.isNotEmpty()) {

--- a/feature/home/src/main/java/com/yapp/ndgl/feature/home/popular/PopularTravelListScreen.kt
+++ b/feature/home/src/main/java/com/yapp/ndgl/feature/home/popular/PopularTravelListScreen.kt
@@ -196,7 +196,8 @@ private fun PopularTravelListContent(
             }.toPersistentList(),
             selectedIndex = state.selectedTabIndex,
             onTabSelected = onTabSelected,
-            modifier = Modifier.padding(start = 24.dp, top = 20.dp),
+            modifier = Modifier.padding(top = 20.dp),
+            contentPadding = PaddingValues(horizontal = 24.dp),
         )
 
         LazyColumn(

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/followtravel/FollowTravelScreen.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/followtravel/FollowTravelScreen.kt
@@ -3,6 +3,7 @@ package com.yapp.ndgl.feature.travel.followtravel
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -145,13 +146,13 @@ private fun FollowTravelScreen(
                             } else {
                                 Modifier.padding(top = 22.dp)
                             },
-                        )
-                        .padding(horizontal = 24.dp),
+                        ),
                 ) {
                     NDGLChipTab(
                         tabs = tabs,
                         selectedIndex = state.selectedDay - 1,
                         onTabSelected = { index -> selectDay(index + 1) },
+                        contentPadding = PaddingValues(horizontal = 24.dp),
                     )
                     Spacer(Modifier.height(16.dp))
                 }

--- a/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/traveldetail/TravelDetailScreen.kt
+++ b/feature/travel/src/main/java/com/yapp/ndgl/feature/travel/traveldetail/TravelDetailScreen.kt
@@ -358,13 +358,13 @@ private fun TravelDetailScreen(
                             } else {
                                 Modifier.padding(top = 22.dp)
                             },
-                        )
-                        .padding(horizontal = 24.dp),
+                        ),
                 ) {
                     NDGLChipTab(
                         tabs = tabs,
                         selectedIndex = state.selectedDay - 1,
                         onTabSelected = { index -> selectDay(index + 1) },
+                        contentPadding = PaddingValues(horizontal = 24.dp),
                     )
                     Spacer(Modifier.height(16.dp))
                 }


### PR DESCRIPTION
[NDGL-125] chore: NDGLChipTab을 LazyRow로 변경 및 contentPadding 적용

---

### 연관 문서

- [NDGLChipTab contentPadding 적용 Task](https://ndglofficial.atlassian.net/jira/software/projects/NDGL/boards/1?selectedIssue=NDGL-125)

### 변경사항

-NDGLChipTab LazyRow 변경 및 contentPadding 적용
- 홈 - 인기 여행 섹션 탭
- 인기 여행 목록 페이지 탭
- 여행 따라가기 일차 탭
- 내 여행 일차 탭

### 테스트 체크 리스트

- [x] 홈 - 인기 여행 섹션 탭
- [x] 인기 여행 목록 페이지 탭
- [x] 여행 따라가기 일차 탭
- [x] 내 여행 일차 탭


[NDGL-125]: https://ndglofficial.atlassian.net/browse/NDGL-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 탭 레이아웃의 성능을 최적화하여 스크롤 처리를 개선했습니다.
  * 패딩 적용 방식을 개선하여 컴포넌트 구조를 더욱 효율적으로 정렬했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->